### PR TITLE
Add react-fc solution

### DIFF
--- a/modules/code-generator/src/index.ts
+++ b/modules/code-generator/src/index.ts
@@ -11,9 +11,11 @@ import { createZipPublisher } from './publisher/zip';
 import createIceJsProjectBuilder, { plugins as icejsPlugins } from './solutions/icejs';
 import createIceJs3ProjectBuilder, { plugins as icejs3Plugins } from './solutions/icejs3';
 import createRaxAppProjectBuilder, { plugins as raxPlugins } from './solutions/rax-app';
+import createReactFCProjectBuilder, { plugins as reactFCPlugins } from './solutions/react-fc';
 
 // 引入说明
 import { REACT_CHUNK_NAME } from './plugins/component/react/const';
+import { REACT_FC_CHUNK_NAME } from './plugins/component/react/fcConst';
 import { COMMON_CHUNK_NAME, CLASS_DEFINE_CHUNK_NAME, DEFAULT_LINK_AFTER } from './const/generator';
 
 // 引入通用插件组
@@ -44,11 +46,13 @@ export default {
     icejs: createIceJsProjectBuilder,
     icejs3: createIceJs3ProjectBuilder,
     rax: createRaxAppProjectBuilder,
+    'react-fc': createReactFCProjectBuilder,
   },
   solutionParts: {
     icejs,
     icejs3,
     rax,
+    'react-fc': icejs,
   },
   publishers: {
     disk: createDiskPublisher,
@@ -83,6 +87,9 @@ export default {
     rax: {
       ...raxPlugins,
     },
+    'react-fc': {
+      ...reactFCPlugins,
+    },
 
     /**
      * @deprecated please use icejs
@@ -99,6 +106,7 @@ export default {
     COMMON_CHUNK_NAME,
     CLASS_DEFINE_CHUNK_NAME,
     REACT_CHUNK_NAME,
+    REACT_FC_CHUNK_NAME,
   },
   defaultLinkAfter: {
     COMMON_DEFAULT_LINK_AFTER: DEFAULT_LINK_AFTER,

--- a/modules/code-generator/src/plugins/component/react/fcConst.ts
+++ b/modules/code-generator/src/plugins/component/react/fcConst.ts
@@ -1,0 +1,12 @@
+export const REACT_FC_CHUNK_NAME = {
+  FunctionComponentDefineStart: 'ReactFCDefineStart',
+  FunctionComponentStateDefine: 'ReactFCStateDefine',
+  FunctionComponentRefDefine: 'ReactFCRefDefine',
+  FunctionComponentCustomHookDefine: 'ReactFCCustomHookDefine',
+  FunctionComponentCallbackDefine: 'ReactFCCallbackDefine',
+  FunctionComponentEffortDefine: 'ReactFCEffortDefine',
+  FunctionComponentInternalVarDefine: 'ReactFCInternalVarDefine',
+  FunctionComponentInternalFunctionDefine: 'ReactFCInternalFunctionDefine',
+  FunctionComponentRender: 'ReactFCRender',
+  FunctionComponentDefineEnd: 'ReactFCDefineEnd',
+};

--- a/modules/code-generator/src/plugins/component/react/fcJsx.ts
+++ b/modules/code-generator/src/plugins/component/react/fcJsx.ts
@@ -1,0 +1,96 @@
+import {
+  BuilderComponentPlugin,
+  BuilderComponentPluginFactory,
+  ChunkType,
+  FileType,
+  HandlerSet,
+  ICodeStruct,
+  IContainerInfo,
+  IScope,
+  NodeGeneratorConfig,
+} from '../../../types';
+import { COMMON_CHUNK_NAME } from '../../../const/generator';
+import { REACT_FC_CHUNK_NAME } from './fcConst';
+import { createReactNodeGenerator } from '../../../utils/nodeToJSX';
+import { Scope } from '../../../utils/Scope';
+import { IPublicTypeJSExpression } from '@alilc/lowcode-types';
+import { generateExpression } from '../../../utils/jsExpression';
+import { transformJsExpr } from '../../../core/jsx/handlers/transformJsExpression';
+import { generateCompositeType } from '../../../utils/compositeType';
+
+export interface PluginConfig {
+  fileType?: string;
+  nodeTypeMapping?: Record<string, string>;
+}
+
+const pluginFactory: BuilderComponentPluginFactory<PluginConfig> = (config?) => {
+  const cfg = {
+    fileType: FileType.JSX,
+    nodeTypeMapping: {} as Record<string, string>,
+    ...config,
+  };
+
+  const { nodeTypeMapping } = cfg;
+
+  const plugin: BuilderComponentPlugin = async (pre: ICodeStruct) => {
+    const next: ICodeStruct = { ...pre };
+    const { tolerateEvalErrors = true, evalErrorsHandler = '' } = next.contextData;
+
+    const customHandlers: HandlerSet<string> = {
+      expression(input: IPublicTypeJSExpression, scope: IScope, config) {
+        return transformJsExpr(generateExpression(input, scope), scope, {
+          dontWrapEval: !(config?.tolerateEvalErrors ?? tolerateEvalErrors),
+          dontTransformThis2ContextAtRootScope: true,
+        });
+      },
+      function(input, scope: IScope) {
+        return generateCompositeType(
+          {
+            type: 'JSFunction',
+            value: input.value || 'function () {}',
+          },
+          Scope.createRootScope(),
+        );
+      },
+    };
+
+    const generatorPlugins: NodeGeneratorConfig = {
+      handlers: customHandlers,
+      tagMapping: (v) => nodeTypeMapping[v] || v,
+      tolerateEvalErrors,
+    };
+
+    const generator = createReactNodeGenerator(generatorPlugins);
+
+    const ir = next.ir as IContainerInfo;
+    const scope: IScope = Scope.createRootScope();
+    const jsxContent = generator(ir, scope);
+
+    next.chunks.push({
+      type: ChunkType.STRING,
+      fileType: cfg.fileType,
+      name: REACT_FC_CHUNK_NAME.FunctionComponentRender,
+      content: `return ${jsxContent};`,
+      linkAfter: [REACT_FC_CHUNK_NAME.FunctionComponentDefineStart],
+    });
+
+    next.chunks.push({
+      type: ChunkType.STRING,
+      fileType: cfg.fileType,
+      name: COMMON_CHUNK_NAME.CustomContent,
+      content: [
+        tolerateEvalErrors &&
+          `function __$$eval(expr){try{return expr();}catch(e){${evalErrorsHandler}}}`,
+        `function __$$evalArray(expr){const res=__$$eval(expr);return Array.isArray(res)?res:[];}`,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      linkAfter: [COMMON_CHUNK_NAME.FileExport],
+    });
+
+    return next;
+  };
+  return plugin;
+};
+
+export default pluginFactory;

--- a/modules/code-generator/src/plugins/component/react/functionComponent.ts
+++ b/modules/code-generator/src/plugins/component/react/functionComponent.ts
@@ -1,0 +1,68 @@
+import changeCase from 'change-case';
+import {
+  COMMON_CHUNK_NAME,
+  DEFAULT_LINK_AFTER,
+} from '../../../const/generator';
+import { ensureValidClassName } from '../../../utils/validate';
+import {
+  BuilderComponentPlugin,
+  BuilderComponentPluginFactory,
+  ChunkType,
+  FileType,
+  ICodeStruct,
+  IContainerInfo,
+} from '../../../types';
+import { REACT_FC_CHUNK_NAME } from './fcConst';
+
+const pluginFactory: BuilderComponentPluginFactory<unknown> = () => {
+  const plugin: BuilderComponentPlugin = async (pre: ICodeStruct) => {
+    const next: ICodeStruct = { ...pre };
+    const ir = next.ir as IContainerInfo;
+    const componentName = ensureValidClassName(changeCase.pascalCase(ir.moduleName));
+
+    next.chunks.push({
+      type: ChunkType.STRING,
+      fileType: FileType.JSX,
+      name: REACT_FC_CHUNK_NAME.FunctionComponentDefineStart,
+      content: `function ${componentName}(props) {`,
+      linkAfter: [
+        COMMON_CHUNK_NAME.ExternalDepsImport,
+        COMMON_CHUNK_NAME.InternalDepsImport,
+        COMMON_CHUNK_NAME.ImportAliasDefine,
+        COMMON_CHUNK_NAME.FileVarDefine,
+        COMMON_CHUNK_NAME.FileUtilDefine,
+      ],
+    });
+
+    next.chunks.push({
+      type: ChunkType.STRING,
+      fileType: FileType.JSX,
+      name: REACT_FC_CHUNK_NAME.FunctionComponentDefineEnd,
+      content: `}`,
+      linkAfter: [
+        REACT_FC_CHUNK_NAME.FunctionComponentDefineStart,
+        REACT_FC_CHUNK_NAME.FunctionComponentRender,
+      ],
+    });
+
+    next.chunks.push({
+      type: ChunkType.STRING,
+      fileType: FileType.JSX,
+      name: COMMON_CHUNK_NAME.FileExport,
+      content: `export default ${componentName};`,
+      linkAfter: [
+        COMMON_CHUNK_NAME.ExternalDepsImport,
+        COMMON_CHUNK_NAME.InternalDepsImport,
+        COMMON_CHUNK_NAME.ImportAliasDefine,
+        COMMON_CHUNK_NAME.FileVarDefine,
+        COMMON_CHUNK_NAME.FileUtilDefine,
+        REACT_FC_CHUNK_NAME.FunctionComponentDefineEnd,
+      ],
+    });
+
+    return next;
+  };
+  return plugin;
+};
+
+export default pluginFactory;

--- a/modules/code-generator/src/solutions/react-fc.ts
+++ b/modules/code-generator/src/solutions/react-fc.ts
@@ -1,0 +1,59 @@
+import { IProjectBuilder, IProjectBuilderOptions } from '../types';
+import { createProjectBuilder } from '../generator/ProjectBuilder';
+import esmodule from '../plugins/common/esmodule';
+import styleImport from '../plugins/common/styleImport';
+import functionComponent from '../plugins/component/react/functionComponent';
+import fcJsx from '../plugins/component/react/fcJsx';
+import reactCommonDeps from '../plugins/component/react/reactCommonDeps';
+import css from '../plugins/component/style/css';
+import constants from '../plugins/project/constants';
+import i18n from '../plugins/project/i18n';
+import utils from '../plugins/project/utils';
+import icejs from '../plugins/project/framework/icejs';
+import { prettier } from '../postprocessor';
+
+export type ReactFCProjectBuilderOptions = IProjectBuilderOptions;
+
+export default function createReactFCProjectBuilder(
+  options?: ReactFCProjectBuilderOptions,
+): IProjectBuilder {
+  return createProjectBuilder({
+    inStrictMode: options?.inStrictMode,
+    extraContextData: { ...options },
+    template: icejs.template,
+    plugins: {
+      components: [
+        reactCommonDeps(),
+        esmodule({ fileType: 'jsx' }),
+        styleImport(),
+        functionComponent(),
+        fcJsx({ nodeTypeMapping: { Div: 'div', Component: 'div', Page: 'div', Block: 'div' } }),
+        css(),
+      ],
+      pages: [
+        reactCommonDeps(),
+        esmodule({ fileType: 'jsx' }),
+        styleImport(),
+        functionComponent(),
+        fcJsx({ nodeTypeMapping: { Div: 'div', Component: 'div', Page: 'div', Block: 'div' } }),
+        css(),
+      ],
+      router: [esmodule(), icejs.plugins.router()],
+      entry: [icejs.plugins.entry()],
+      constants: [constants()],
+      utils: [esmodule(), utils('react')],
+      i18n: [i18n()],
+      globalStyle: [icejs.plugins.globalStyle()],
+      htmlEntry: [icejs.plugins.entryHtml()],
+      packageJSON: [icejs.plugins.packageJSON()],
+    },
+    postProcessors: [prettier()],
+    customizeBuilderOptions: options?.customizeBuilderOptions,
+  });
+}
+
+export const plugins = {
+  functionComponent,
+  fcJsx,
+  commonDeps: reactCommonDeps,
+};


### PR DESCRIPTION
## Summary
- add constant set for React functional component chunk names
- add plugins for React FC definition and JSX rendering
- create `react-fc` solution exposing new plugins
- expose solution in public API

## Testing
- `npm run lint:modules` *(fails: f2elint not found)*
- `npm test` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdce1462c832690a4acc8604abd3b